### PR TITLE
Add locality-sensitive hashing and fix indexing bugs

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,23 +1,22 @@
 use vector_db::{
-    vector::Vector,
-    storage::InMemoryStorage,
-    index::BruteForceIndex,
-    query::QueryEngine,
-    utils::generate_random_vectors,
+    index::{HNSWIndex, Index},
     persistence::PersistentStorage,
+    query::QueryEngine,
+    storage::{InMemoryStorage, Storage},
+    utils::generate_random_vectors,
+    vector::Vector,
 };
-use ndarray::Array1;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🚀 Vector Database Demo");
+    println!("Vector Database Demo");
     println!("======================\n");
 
     // Create storage and index
     let mut storage = InMemoryStorage::new();
-    let mut index = BruteForceIndex::new();
+    let mut index = HNSWIndex::new(16, 32);
 
     // Generate some random vectors
-    println!("📊 Generating 100 random 128-dimensional vectors...");
+    println!("Generating 100 random 128-dimensional vectors...");
     let vectors_data = generate_random_vectors(128, 100);
     let mut vectors = Vec::new();
 
@@ -25,15 +24,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let vector = Vector::new(data);
         vectors.push(vector.clone());
         storage.insert(vector).unwrap();
-        
+
         if (i + 1) % 20 == 0 {
             println!("  Inserted {} vectors", i + 1);
         }
     }
 
     // Build the index
-    println!("\n🔍 Building search index...");
-    let indexed_data: Vec<_> = storage.all_vectors()
+    println!("\nBuilding search index...");
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
         .iter()
         .map(|v| (&v.id, &v.data))
         .collect();
@@ -43,55 +43,68 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let query_engine = QueryEngine::new(&storage, &index);
 
     // Perform some searches
-    println!("\n🔎 Performing similarity searches...");
-    
+    println!("\nPerforming similarity searches...");
+
     // Search 1: Find similar vectors to the first vector
     let query_vector1 = &vectors[0];
-    println!("Search 1: Finding vectors similar to vector {}", query_vector1.id);
-    
+    println!(
+        "Search 1: Finding vectors similar to vector {}",
+        query_vector1.id
+    );
+
     let results1 = query_engine.search_with_scores(query_vector1, 5).unwrap();
     for (i, (vector, score)) in results1.iter().enumerate() {
-        println!("  {}. Vector {} - Similarity: {:.4}", i + 1, vector.id, score);
+        println!(
+            "  {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector.id,
+            score
+        );
     }
 
     // Search 2: Find similar vectors to a random query
     let random_query_data = generate_random_vectors(128, 1)[0].clone();
     let random_query = Vector::new(random_query_data);
     println!("\nSearch 2: Finding vectors similar to a random query vector");
-    
+
     let results2 = query_engine.search_with_scores(&random_query, 3).unwrap();
     for (i, (vector, score)) in results2.iter().enumerate() {
-        println!("  {}. Vector {} - Similarity: {:.4}", i + 1, vector.id, score);
+        println!(
+            "  {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector.id,
+            score
+        );
     }
 
     // Demonstrate persistence
-    println!("\n💾 Testing persistence...");
+    println!("\nTesting persistence...");
     let temp_path = std::env::temp_dir().join("demo_vectors.json");
     let persistence = PersistentStorage::new(&temp_path);
-    
+
     // Save all vectors
     persistence.save(&vectors).unwrap();
     println!("  Saved {} vectors to {:?}", vectors.len(), temp_path);
-    
+
     // Load vectors back
     let loaded_vectors = persistence.load().unwrap();
     println!("  Loaded {} vectors from disk", loaded_vectors.len());
-    
+
     // Verify they're the same
     assert_eq!(vectors.len(), loaded_vectors.len());
-    println!("  ✅ Persistence test passed!");
+    println!("  Persistence test passed!");
 
     // Performance metrics
-    println!("\n📈 Performance Summary:");
+    println!("\nPerformance Summary:");
     println!("  Total vectors: {}", storage.count());
     println!("  Vector dimension: {}", vectors[0].dimension());
     println!("  Storage type: InMemory");
-    println!("  Index type: BruteForce");
+    println!("  Index type: HNSW");
 
     // Cleanup
     persistence.clear().unwrap();
-    println!("\n🧹 Cleaned up temporary files");
+    println!("\nCleaned up temporary files");
 
-    println!("\n✅ Demo completed successfully!");
+    println!("\nDemo completed successfully!");
     Ok(())
-} 
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,11 +1,13 @@
-use uuid::Uuid;
+use crate::utils::{cosine_similarity, euclidean_distance};
 use crate::Result;
 use ndarray::Array1;
-use crate::utils::{cosine_similarity, euclidean_distance};
+use rand::Rng;
+use std::collections::{HashMap, HashSet, VecDeque};
+use uuid::Uuid;
 
 pub trait Index {
     fn build(&mut self, vectors: &[(&Uuid, &Array1<f32>)]) -> Result<()>;
-    fn query(&self, query: &Array1<f32>, top_k: usize) -> Vec<(Uuid, f32)>;
+    fn query(&self, query: &Array1<f32>, top_k: usize) -> Result<Vec<(Uuid, f32)>>;
     fn clear(&mut self);
 }
 
@@ -41,7 +43,7 @@ impl BruteForceIndex {
 
         // Sort by similarity (descending for cosine, ascending for negative euclidean)
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        
+
         results.into_iter().take(top_k).collect()
     }
 }
@@ -50,13 +52,14 @@ impl Index for BruteForceIndex {
     fn build(&mut self, vectors: &[(&Uuid, &Array1<f32>)]) -> Result<()> {
         self.indexed_vectors.clear();
         for (id, vector) in vectors {
-            self.indexed_vectors.push((**id, vector.clone()));
+            // `vector` is a reference to a reference, so dereference before cloning
+            self.indexed_vectors.push((**id, (*vector).clone()));
         }
         Ok(())
     }
 
-    fn query(&self, query: &Array1<f32>, top_k: usize) -> Vec<(Uuid, f32)> {
-        self.query_with_similarity(query, top_k, true) // Default to cosine similarity
+    fn query(&self, query: &Array1<f32>, top_k: usize) -> Result<Vec<(Uuid, f32)>> {
+        Ok(self.query_with_similarity(query, top_k, true)) // Default to cosine similarity
     }
 
     fn clear(&mut self) {
@@ -68,4 +71,298 @@ impl Default for BruteForceIndex {
     fn default() -> Self {
         Self::new()
     }
-} 
+}
+
+/// Locality-Sensitive Hashing (LSH) index using random hyperplane projection.
+/// This index approximates nearest neighbour search by hashing vectors into
+/// buckets based on the sign of their projection onto a set of random
+/// hyperplanes. During querying, only vectors that fall into the same bucket as
+/// the query are compared, providing a faster albeit approximate search.
+pub struct LSHIndex {
+    num_planes: usize,
+    hyperplanes: Vec<Array1<f32>>,
+    buckets: HashMap<u64, Vec<(Uuid, Array1<f32>)>>,
+    all_vectors: Vec<(Uuid, Array1<f32>)>,
+}
+
+impl LSHIndex {
+    /// Create a new LSH index with the specified number of hyperplanes.
+    pub fn new(num_planes: usize) -> Self {
+        Self {
+            num_planes,
+            hyperplanes: Vec::new(),
+            buckets: HashMap::new(),
+            all_vectors: Vec::new(),
+        }
+    }
+
+    fn compute_hash(&self, vector: &Array1<f32>) -> u64 {
+        let mut hash: u64 = 0;
+        for (i, plane) in self.hyperplanes.iter().enumerate() {
+            if vector.dot(plane) >= 0.0 {
+                hash |= 1 << i;
+            }
+        }
+        hash
+    }
+
+    fn query_bucket(&self, query: &Array1<f32>, top_k: usize) -> Vec<(Uuid, f32)> {
+        let hash = self.compute_hash(query);
+        let candidates = self.buckets.get(&hash).cloned().unwrap_or_default();
+
+        let mut results: Vec<(Uuid, f32)> = candidates
+            .iter()
+            .map(|(id, vector)| (*id, cosine_similarity(query, vector)))
+            .collect();
+
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.into_iter().take(top_k).collect()
+    }
+}
+
+impl Index for LSHIndex {
+    fn build(&mut self, vectors: &[(&Uuid, &Array1<f32>)]) -> Result<()> {
+        self.buckets.clear();
+        self.hyperplanes.clear();
+        self.all_vectors.clear();
+
+        if vectors.is_empty() {
+            return Ok(());
+        }
+
+        let dim = vectors[0].1.len();
+        let mut rng = rand::thread_rng();
+        self.hyperplanes = (0..self.num_planes)
+            .map(|_| {
+                Array1::from(
+                    (0..dim)
+                        .map(|_| rng.gen_range(-1.0..1.0))
+                        .collect::<Vec<f32>>(),
+                )
+            })
+            .collect();
+
+        for (id, vector) in vectors {
+            let vec_clone = (*vector).clone();
+            let hash = self.compute_hash(&vec_clone);
+            self.buckets
+                .entry(hash)
+                .or_insert_with(Vec::new)
+                .push((**id, vec_clone.clone()));
+            self.all_vectors.push((**id, vec_clone));
+        }
+
+        Ok(())
+    }
+
+    fn query(&self, query: &Array1<f32>, top_k: usize) -> Result<Vec<(Uuid, f32)>> {
+        let mut results = self.query_bucket(query, top_k);
+
+        if results.len() < top_k {
+            // Fall back to brute-force over all vectors to ensure we return enough results
+            let mut all_results: Vec<(Uuid, f32)> = self
+                .all_vectors
+                .iter()
+                .map(|(id, vector)| (*id, cosine_similarity(query, vector)))
+                .collect();
+            all_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            results = all_results.into_iter().take(top_k).collect();
+        }
+
+        Ok(results)
+    }
+
+    fn clear(&mut self) {
+        self.buckets.clear();
+        self.hyperplanes.clear();
+        self.all_vectors.clear();
+    }
+}
+
+impl Default for LSHIndex {
+    fn default() -> Self {
+        Self::new(16)
+    }
+}
+
+/// A simple implementation of the Hierarchical Navigable Small World (HNSW)
+/// graph for approximate nearest neighbour search. This implementation focuses
+/// on clarity over performance and is suitable for small datasets.
+pub struct HNSWIndex {
+    m: usize,
+    ef: usize,
+    nodes: Vec<HNSWNode>,
+    entry: Option<usize>,
+    max_level: usize,
+}
+
+struct HNSWNode {
+    id: Uuid,
+    vector: Array1<f32>,
+    level: usize,
+    neighbours: Vec<Vec<usize>>, // neighbours per level
+}
+
+impl HNSWIndex {
+    /// Create a new HNSW index.
+    pub fn new(m: usize, ef: usize) -> Self {
+        Self {
+            m,
+            ef,
+            nodes: Vec::new(),
+            entry: None,
+            max_level: 0,
+        }
+    }
+
+    fn random_level(&self) -> usize {
+        let mut level = 0usize;
+        let mut rng = rand::thread_rng();
+        while rng.gen::<f32>() < 0.5 {
+            level += 1;
+        }
+        level
+    }
+
+    fn distance(a: &Array1<f32>, b: &Array1<f32>) -> f32 {
+        1.0 - cosine_similarity(a, b)
+    }
+
+    fn insert_node(&mut self, id: Uuid, vector: Array1<f32>) {
+        let level = self.random_level();
+        let idx = self.nodes.len();
+        let node = HNSWNode {
+            id,
+            vector,
+            level,
+            neighbours: vec![Vec::new(); level + 1],
+        };
+        if self.entry.is_none() {
+            self.entry = Some(idx);
+            self.max_level = level;
+        }
+        self.nodes.push(node);
+
+        // Connect to existing nodes
+        for i in 0..idx {
+            let max_lvl = usize::min(level, self.nodes[i].level);
+            for l in 0..=max_lvl {
+                self.nodes[idx].neighbours[l].push(i);
+                self.nodes[i].neighbours[l].push(idx);
+
+                // Keep only M closest neighbours per level
+                if self.nodes[idx].neighbours[l].len() > self.m {
+                    self.prune_neighbours(idx, l);
+                }
+                if self.nodes[i].neighbours[l].len() > self.m {
+                    self.prune_neighbours(i, l);
+                }
+            }
+        }
+
+        if level > self.max_level {
+            self.max_level = level;
+            self.entry = Some(idx);
+        }
+    }
+
+    fn prune_neighbours(&mut self, node_idx: usize, level: usize) {
+        let vector = self.nodes[node_idx].vector.clone();
+        let mut neigh = self.nodes[node_idx].neighbours[level]
+            .clone()
+            .into_iter()
+            .map(|n| {
+                let d = Self::distance(&vector, &self.nodes[n].vector);
+                (n, d)
+            })
+            .collect::<Vec<_>>();
+        neigh.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        neigh.truncate(self.m);
+        self.nodes[node_idx].neighbours[level] = neigh.into_iter().map(|(n, _)| n).collect();
+    }
+
+    fn greedy_search(&self, query: &Array1<f32>, start: usize, level: usize) -> usize {
+        let mut current = start;
+        loop {
+            let mut changed = false;
+            let mut best_dist = Self::distance(query, &self.nodes[current].vector);
+            for &n in &self.nodes[current].neighbours[level] {
+                let dist = Self::distance(query, &self.nodes[n].vector);
+                if dist < best_dist {
+                    best_dist = dist;
+                    current = n;
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        current
+    }
+}
+
+impl Index for HNSWIndex {
+    fn build(&mut self, vectors: &[(&Uuid, &Array1<f32>)]) -> Result<()> {
+        self.clear();
+        for (id, vector) in vectors {
+            self.insert_node(**id, (*vector).clone());
+        }
+        Ok(())
+    }
+
+    fn query(&self, query: &Array1<f32>, top_k: usize) -> Result<Vec<(Uuid, f32)>> {
+        if self.nodes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Greedy search through upper layers
+        let mut current = self.entry.unwrap();
+        for level in (1..=self.max_level).rev() {
+            current = self.greedy_search(query, current, level);
+        }
+
+        // Breadth-first search at level 0
+        let mut visited: HashSet<usize> = HashSet::new();
+        let mut queue: VecDeque<usize> = VecDeque::new();
+        queue.push_back(current);
+        visited.insert(current);
+
+        while let Some(idx) = queue.pop_front() {
+            for &n in &self.nodes[idx].neighbours[0] {
+                if visited.len() >= self.ef {
+                    break;
+                }
+                if visited.insert(n) {
+                    queue.push_back(n);
+                }
+            }
+            if visited.len() >= self.ef {
+                break;
+            }
+        }
+
+        let mut results: Vec<(Uuid, f32)> = visited
+            .into_iter()
+            .map(|i| {
+                let node = &self.nodes[i];
+                (node.id, cosine_similarity(query, &node.vector))
+            })
+            .collect();
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        results.truncate(top_k);
+        Ok(results)
+    }
+
+    fn clear(&mut self) {
+        self.nodes.clear();
+        self.entry = None;
+        self.max_level = 0;
+    }
+}
+
+impl Default for HNSWIndex {
+    fn default() -> Self {
+        Self::new(16, 32)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-pub mod storage;
 pub mod index;
-pub mod query;
-pub mod vector;
 pub mod persistence;
+pub mod query;
+pub mod storage;
 pub mod utils;
+pub mod vector;
 
 use thiserror::Error;
 
@@ -24,9 +24,9 @@ pub enum VectorDBError {
 pub type Result<T> = std::result::Result<T, VectorDBError>;
 
 // Re-export main types for convenience
-pub use storage::{Storage, InMemoryStorage};
-pub use index::{Index, BruteForceIndex};
-pub use query::QueryEngine;
-pub use vector::Vector;
+pub use index::{BruteForceIndex, HNSWIndex, Index, LSHIndex};
 pub use persistence::PersistentStorage;
-pub use utils::{cosine_similarity, euclidean_distance}; 
+pub use query::QueryEngine;
+pub use storage::{InMemoryStorage, Storage};
+pub use utils::{cosine_similarity, euclidean_distance};
+pub use vector::Vector;

--- a/src/query.rs
+++ b/src/query.rs
@@ -13,7 +13,7 @@ impl<'a> QueryEngine<'a> {
     }
 
     pub fn search(&self, query_vector: &Vector, top_k: usize) -> Result<Vec<&Vector>> {
-        let results = self.index.query(&query_vector.data, top_k);
+        let results = self.index.query(&query_vector.data, top_k)?;
         
         let mut vectors = Vec::new();
         for (id, _similarity) in results {
@@ -26,7 +26,7 @@ impl<'a> QueryEngine<'a> {
     }
 
     pub fn search_with_scores(&self, query_vector: &Vector, top_k: usize) -> Result<Vec<(&Vector, f32)>> {
-        let results = self.index.query(&query_vector.data, top_k);
+        let results = self.index.query(&query_vector.data, top_k)?;
         
         let mut vectors_with_scores = Vec::new();
         for (id, similarity) in results {
@@ -39,7 +39,7 @@ impl<'a> QueryEngine<'a> {
     }
 
     pub fn search_by_vector(&self, query_data: &Array1<f32>, top_k: usize) -> Result<Vec<&Vector>> {
-        let results = self.index.query(query_data, top_k);
+        let results = self.index.query(query_data, top_k)?;
         
         let mut vectors = Vec::new();
         for (id, _similarity) in results {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,47 +1,47 @@
-use vector_db::{
-    vector::Vector,
-    storage::InMemoryStorage,
-    index::BruteForceIndex,
-    query::QueryEngine,
-    utils::{generate_random_vectors, cosine_similarity, euclidean_distance},
-    persistence::PersistentStorage,
-};
 use ndarray::Array1;
-use std::collections::HashMap;
+use vector_db::{
+    index::{BruteForceIndex, HNSWIndex, Index, LSHIndex},
+    persistence::PersistentStorage,
+    query::QueryEngine,
+    storage::{InMemoryStorage, Storage},
+    utils::{cosine_similarity, euclidean_distance, generate_random_vectors},
+    vector::Vector,
+};
 
 #[test]
 fn test_end_to_end_query() {
     // Create test vectors
     let vectors_data = generate_random_vectors(128, 100);
     let mut vectors = Vec::new();
-    
+
     for data in vectors_data {
         vectors.push(Vector::new(data));
     }
-    
+
     // Setup storage and index
     let mut storage = InMemoryStorage::new();
     let mut index = BruteForceIndex::new();
-    
+
     // Insert vectors into storage
     for vector in &vectors {
         storage.insert(vector.clone()).unwrap();
     }
-    
+
     // Build index
-    let indexed_data: Vec<_> = storage.all_vectors()
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
         .iter()
         .map(|v| (&v.id, &v.data))
         .collect();
     index.build(&indexed_data).unwrap();
-    
+
     // Create query engine
     let query_engine = QueryEngine::new(&storage, &index);
-    
+
     // Test query
     let query_vector = Vector::new(generate_random_vectors(128, 1)[0].clone());
     let results = query_engine.search(&query_vector, 5).unwrap();
-    
+
     assert_eq!(results.len(), 5);
     assert!(results.len() <= 5);
 }
@@ -53,30 +53,31 @@ fn test_cosine_similarity_ordering() {
     let v2 = Array1::from_vec(vec![0.0, 1.0, 0.0]);
     let v3 = Array1::from_vec(vec![0.0, 0.0, 1.0]);
     let query = Array1::from_vec(vec![1.0, 0.0, 0.0]);
-    
+
     let vectors = vec![
         Vector::with_id(uuid::Uuid::new_v4(), v1),
         Vector::with_id(uuid::Uuid::new_v4(), v2),
         Vector::with_id(uuid::Uuid::new_v4(), v3),
     ];
-    
+
     let mut storage = InMemoryStorage::new();
     let mut index = BruteForceIndex::new();
-    
+
     for vector in &vectors {
         storage.insert(vector.clone()).unwrap();
     }
-    
-    let indexed_data: Vec<_> = storage.all_vectors()
+
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
         .iter()
         .map(|v| (&v.id, &v.data))
         .collect();
     index.build(&indexed_data).unwrap();
-    
+
     let query_engine = QueryEngine::new(&storage, &index);
     let query_vector = Vector::new(query);
     let results = query_engine.search_with_scores(&query_vector, 3).unwrap();
-    
+
     // The first result should have the highest cosine similarity with the query
     assert!(results.len() > 0);
     assert!(results[0].1 >= results[1].1);
@@ -86,28 +87,25 @@ fn test_cosine_similarity_ordering() {
 #[test]
 fn test_persistence() {
     let vectors_data = generate_random_vectors(64, 10);
-    let vectors: Vec<Vector> = vectors_data
-        .into_iter()
-        .map(Vector::new)
-        .collect();
-    
+    let vectors: Vec<Vector> = vectors_data.into_iter().map(Vector::new).collect();
+
     let temp_path = std::env::temp_dir().join("test_vectors.json");
     let persistence = PersistentStorage::new(&temp_path);
-    
+
     // Save vectors
     persistence.save(&vectors).unwrap();
-    
+
     // Load vectors
     let loaded_vectors = persistence.load().unwrap();
-    
+
     assert_eq!(vectors.len(), loaded_vectors.len());
-    
+
     // Verify vectors are the same
     for (original, loaded) in vectors.iter().zip(loaded_vectors.iter()) {
         assert_eq!(original.id, loaded.id);
         assert_eq!(original.data, loaded.data);
     }
-    
+
     // Cleanup
     persistence.clear().unwrap();
 }
@@ -115,17 +113,17 @@ fn test_persistence() {
 #[test]
 fn test_storage_operations() {
     let mut storage = InMemoryStorage::new();
-    
+
     // Test insert and get
     let vector = Vector::new(Array1::from_vec(vec![1.0, 2.0, 3.0]));
     let vector_id = vector.id;
-    
+
     storage.insert(vector).unwrap();
     assert_eq!(storage.count(), 1);
-    
+
     let retrieved = storage.get(&vector_id).unwrap();
     assert_eq!(retrieved.data, Array1::from_vec(vec![1.0, 2.0, 3.0]));
-    
+
     // Test delete
     storage.delete(&vector_id).unwrap();
     assert_eq!(storage.count(), 0);
@@ -135,25 +133,19 @@ fn test_storage_operations() {
 #[test]
 fn test_index_operations() {
     let mut index = BruteForceIndex::new();
-    
+
     let vectors_data = generate_random_vectors(32, 5);
-    let vectors: Vec<Vector> = vectors_data
-        .into_iter()
-        .map(Vector::new)
-        .collect();
-    
-    let indexed_data: Vec<_> = vectors
-        .iter()
-        .map(|v| (&v.id, &v.data))
-        .collect();
-    
+    let vectors: Vec<Vector> = vectors_data.into_iter().map(Vector::new).collect();
+
+    let indexed_data: Vec<_> = vectors.iter().map(|v| (&v.id, &v.data)).collect();
+
     index.build(&indexed_data).unwrap();
-    
-    let query = Array1::from_vec(vec![0.5, 0.5, 0.5, 0.5]);
+
+    let query = generate_random_vectors(32, 1)[0].clone();
     let results = index.query(&query, 3).unwrap();
-    
+
     assert_eq!(results.len(), 3);
-    
+
     index.clear();
     let results_after_clear = index.query(&query, 3).unwrap();
     assert_eq!(results_after_clear.len(), 0);
@@ -164,18 +156,18 @@ fn test_distance_metrics() {
     let v1 = Array1::from_vec(vec![1.0, 0.0, 0.0]);
     let v2 = Array1::from_vec(vec![0.0, 1.0, 0.0]);
     let v3 = Array1::from_vec(vec![1.0, 0.0, 0.0]);
-    
+
     // Test cosine similarity
     let sim_12 = cosine_similarity(&v1, &v2);
     let sim_13 = cosine_similarity(&v1, &v3);
-    
+
     assert_eq!(sim_12, 0.0); // Perpendicular vectors
     assert_eq!(sim_13, 1.0); // Same direction
-    
+
     // Test euclidean distance
     let dist_12 = euclidean_distance(&v1, &v2);
     let dist_13 = euclidean_distance(&v1, &v3);
-    
+
     assert_eq!(dist_12, 2.0_f32.sqrt());
     assert_eq!(dist_13, 0.0);
 }
@@ -184,37 +176,74 @@ fn test_distance_metrics() {
 fn test_query_engine_with_metadata() {
     let mut storage = InMemoryStorage::new();
     let mut index = BruteForceIndex::new();
-    
+
     // Create vectors with metadata
     let metadata1 = serde_json::json!({"label": "cat", "confidence": 0.95});
     let metadata2 = serde_json::json!({"label": "dog", "confidence": 0.87});
-    
-    let vector1 = Vector::with_metadata(
-        Array1::from_vec(vec![1.0, 0.0, 0.0]),
-        metadata1
-    );
-    let vector2 = Vector::with_metadata(
-        Array1::from_vec(vec![0.0, 1.0, 0.0]),
-        metadata2
-    );
-    
+
+    let vector1 = Vector::with_metadata(Array1::from_vec(vec![1.0, 0.0, 0.0]), metadata1);
+    let vector2 = Vector::with_metadata(Array1::from_vec(vec![0.0, 1.0, 0.0]), metadata2);
+
     storage.insert(vector1.clone()).unwrap();
     storage.insert(vector2.clone()).unwrap();
-    
-    let indexed_data: Vec<_> = storage.all_vectors()
+
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
         .iter()
         .map(|v| (&v.id, &v.data))
         .collect();
     index.build(&indexed_data).unwrap();
-    
+
     let query_engine = QueryEngine::new(&storage, &index);
     let query_vector = Vector::new(Array1::from_vec(vec![1.0, 0.0, 0.0]));
-    
+
     let results = query_engine.search_with_scores(&query_vector, 2).unwrap();
-    
+
     assert_eq!(results.len(), 2);
-    
+
     // Check that metadata is preserved
     let first_result = results[0].0;
     assert!(first_result.metadata.is_some());
-} 
+}
+
+#[test]
+fn test_lsh_index_query() {
+    let vectors_data = generate_random_vectors(16, 20);
+    let vectors: Vec<Vector> = vectors_data.into_iter().map(Vector::new).collect();
+
+    let mut storage = InMemoryStorage::new();
+    for v in &vectors {
+        storage.insert(v.clone()).unwrap();
+    }
+
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
+        .iter()
+        .map(|v| (&v.id, &v.data))
+        .collect();
+
+    let mut index = LSHIndex::new(8);
+    index.build(&indexed_data).unwrap();
+
+    let query = generate_random_vectors(16, 1)[0].clone();
+    let results = index.query(&query, 5).unwrap();
+
+    assert!(results.len() <= 5);
+}
+
+#[test]
+fn test_hnsw_index_query() {
+    let vectors_data = generate_random_vectors(32, 20);
+    let vectors: Vec<Vector> = vectors_data.into_iter().map(Vector::new).collect();
+
+    let indexed_data: Vec<_> = vectors.iter().map(|v| (&v.id, &v.data)).collect();
+
+    let mut index = HNSWIndex::new(8, 16);
+    index.build(&indexed_data).unwrap();
+
+    let query = vectors[0].data.clone();
+    let results = index.query(&query, 1).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, vectors[0].id);
+}

--- a/vector_db/examples/basic_usage.rs
+++ b/vector_db/examples/basic_usage.rs
@@ -1,15 +1,15 @@
-use vector_db::{
-    vector::Vector,
-    storage::{InMemoryStorage, Storage},
-    index::{BruteForceIndex, Index},
-    query::QueryEngine,
-    utils::generate_random_vectors,
-    persistence::PersistentStorage,
-};
 use ndarray::Array1;
+use vector_db::{
+    index::{BruteForceIndex, Index},
+    persistence::PersistentStorage,
+    query::QueryEngine,
+    storage::{InMemoryStorage, Storage},
+    utils::generate_random_vectors,
+    vector::Vector,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🚀 Vector Database Demo");
+    println!(" Vector Database Demo");
     println!("======================\n");
 
     // Create storage and index
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut index = BruteForceIndex::new();
 
     // Generate some random vectors
-    println!("📊 Generating 100 random 128-dimensional vectors...");
+    println!(" Generating 100 random 128-dimensional vectors...");
     let vectors_data = generate_random_vectors(128, 100);
     let mut vectors = Vec::new();
 
@@ -25,15 +25,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let vector = Vector::new(data);
         vectors.push(vector.clone());
         storage.insert(vector).unwrap();
-        
+
         if (i + 1) % 20 == 0 {
             println!("  Inserted {} vectors", i + 1);
         }
     }
 
     // Build the index
-    println!("\n🔍 Building search index...");
-    let indexed_data: Vec<_> = storage.all_vectors()
+    println!("\n Building search index...");
+    let indexed_data: Vec<_> = storage
+        .all_vectors()
         .iter()
         .map(|v| (&v.id, &v.data))
         .collect();
@@ -43,46 +44,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let query_engine = QueryEngine::new(&storage, &index);
 
     // Perform some searches
-    println!("\n🔎 Performing similarity searches...");
-    
+    println!("\n Performing similarity searches...");
+
     // Search 1: Find similar vectors to the first vector
     let query_vector1 = &vectors[0];
-    println!("Search 1: Finding vectors similar to vector {}", query_vector1.id);
-    
+    println!(
+        "Search 1: Finding vectors similar to vector {}",
+        query_vector1.id
+    );
+
     let results1 = query_engine.search_with_scores(query_vector1, 5).unwrap();
     for (i, (vector, score)) in results1.iter().enumerate() {
-        println!("  {}. Vector {} - Similarity: {:.4}", i + 1, vector.id, score);
+        println!(
+            "  {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector.id,
+            score
+        );
     }
 
     // Search 2: Find similar vectors to a random query
     let random_query_data = generate_random_vectors(128, 1)[0].clone();
     let random_query = Vector::new(random_query_data);
     println!("\nSearch 2: Finding vectors similar to a random query vector");
-    
+
     let results2 = query_engine.search_with_scores(&random_query, 3).unwrap();
     for (i, (vector, score)) in results2.iter().enumerate() {
-        println!("  {}. Vector {} - Similarity: {:.4}", i + 1, vector.id, score);
+        println!(
+            "  {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector.id,
+            score
+        );
     }
 
     // Demonstrate persistence
-    println!("\n💾 Testing persistence...");
+    println!("\n Testing persistence...");
     let temp_path = std::env::temp_dir().join("demo_vectors.json");
     let persistence = PersistentStorage::new(&temp_path);
-    
+
     // Save all vectors
     persistence.save(&vectors).unwrap();
     println!("  Saved {} vectors to {:?}", vectors.len(), temp_path);
-    
+
     // Load vectors back
     let loaded_vectors = persistence.load().unwrap();
     println!("  Loaded {} vectors from disk", loaded_vectors.len());
-    
+
     // Verify they're the same
     assert_eq!(vectors.len(), loaded_vectors.len());
-    println!("  ✅ Persistence test passed!");
+    println!("   Persistence test passed!");
 
     // Performance metrics
-    println!("\n📈 Performance Summary:");
+    println!("\n Performance Summary:");
     println!("  Total vectors: {}", storage.count());
     println!("  Vector dimension: {}", vectors[0].dimension());
     println!("  Storage type: InMemory");
@@ -90,8 +104,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Cleanup
     persistence.clear().unwrap();
-    println!("\n🧹 Cleaned up temporary files");
+    println!("\n Cleaned up temporary files");
 
-    println!("\n✅ Demo completed successfully!");
+    println!("\n Demo completed successfully!");
     Ok(())
-} 
+}

--- a/vector_db/examples/debug_file.rs
+++ b/vector_db/examples/debug_file.rs
@@ -1,55 +1,55 @@
-use vector_db::{
-    vector::Vector,
-    local_storage::LocalStorage,
-};
 use ndarray::Array1;
 use serde_json::json;
-use tempfile::TempDir;
 use std::fs;
+use tempfile::TempDir;
+use vector_db::{local_storage::LocalStorage, vector::Vector};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🔍 Debug File Content");
+    println!(" Debug File Content");
     println!("====================");
 
     let temp_dir = TempDir::new()?;
-    println!("📁 Temp directory: {:?}", temp_dir.path());
+    println!(" Temp directory: {:?}", temp_dir.path());
 
     // Create storage
     let mut storage = LocalStorage::new(temp_dir.path())?;
-    println!("✅ Storage created");
+    println!(" Storage created");
 
     // Create a simple vector
     let data = Array1::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
     let metadata = json!({"test": "metadata", "value": 42});
     let vector = Vector::with_metadata(data, metadata);
-    
-    println!("📊 Vector created: {}", vector.id);
+
+    println!(" Vector created: {}", vector.id);
 
     // Add vector
     storage.add_vector(&vector)?;
-    println!("✅ Vector added to storage");
+    println!(" Vector added to storage");
 
     // Check file content
     let vectors_file = storage.get_storage_path().join("vectors.kwi");
     if vectors_file.exists() {
-        println!("📄 File exists: {:?}", vectors_file);
+        println!(" File exists: {:?}", vectors_file);
         let file_size = fs::metadata(&vectors_file)?.len();
-        println!("📏 File size: {} bytes", file_size);
-        
+        println!(" File size: {} bytes", file_size);
+
         // Read first 100 bytes
         let content = fs::read(&vectors_file)?;
-        println!("📖 First 100 bytes: {:?}", &content[..content.len().min(100)]);
-        
+        println!(" First 100 bytes: {:?}", &content[..content.len().min(100)]);
+
         // Show hex dump
-        println!("🔢 Hex dump:");
+        println!(" Hex dump:");
         for (i, chunk) in content.chunks(16).enumerate().take(10) {
             let hex: String = chunk.iter().map(|b| format!("{:02x} ", b)).collect();
-            let ascii: String = chunk.iter().map(|&b| if b >= 32 && b <= 126 { b as char } else { '.' }).collect();
+            let ascii: String = chunk
+                .iter()
+                .map(|&b| if b >= 32 && b <= 126 { b as char } else { '.' })
+                .collect();
             println!("{:04x}: {} |{}|", i * 16, hex, ascii);
         }
     } else {
-        println!("❌ File does not exist");
+        println!(" File does not exist");
     }
 
     Ok(())
-} 
+}

--- a/vector_db/examples/debug_local_storage.rs
+++ b/vector_db/examples/debug_local_storage.rs
@@ -1,63 +1,58 @@
-use vector_db::{
-    vector::Vector,
-    local_storage::LocalStorage,
-};
 use ndarray::Array1;
 use serde_json::json;
-use tempfile::TempDir;
 use std::fs;
 use std::io::Read;
+use tempfile::TempDir;
+use vector_db::{local_storage::LocalStorage, vector::Vector};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🔍 Debugging Local Storage");
+    println!(" Debugging Local Storage");
     println!("==========================");
 
     let temp_dir = TempDir::new()?;
-    println!("📁 Temp directory: {:?}", temp_dir.path());
+    println!(" Temp directory: {:?}", temp_dir.path());
 
     // Create storage
     let mut storage = LocalStorage::new(temp_dir.path())?;
-    println!("✅ Storage created");
-    
+    println!(" Storage created");
+
     // Clear any existing data
     storage.clear()?;
-    println!("🧹 Storage cleared");
+    println!(" Storage cleared");
 
     // Create a simple vector
     let data = Array1::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
     let metadata = json!({"test": "metadata", "value": 42});
     let vector = Vector::with_metadata(data, metadata);
-    
-    println!("📊 Vector created: {}", vector.id);
+
+    println!(" Vector created: {}", vector.id);
     println!("   Data: {:?}", vector.data);
     println!("   Metadata: {:?}", vector.metadata);
 
     // Add vector
     storage.add_vector(&vector)?;
-    println!("✅ Vector added to storage");
+    println!(" Vector added to storage");
 
     // Check count
     let count = storage.get_vector_count()?;
-    println!("📈 Vector count: {}", count);
-
-
+    println!(" Vector count: {}", count);
 
     // Try to retrieve vector
     let retrieved = storage.get_vector(&vector.id)?;
     match retrieved {
         Some(retrieved_vector) => {
-            println!("✅ Vector retrieved successfully!");
+            println!(" Vector retrieved successfully!");
             println!("   ID: {}", retrieved_vector.id);
             println!("   Data: {:?}", retrieved_vector.data);
             println!("   Metadata: {:?}", retrieved_vector.metadata);
         }
         None => {
-            println!("❌ Failed to retrieve vector");
-            
+            println!(" Failed to retrieve vector");
+
             // Debug: try to get all vectors
             let all_vectors = storage.get_all_vectors()?;
-            println!("📋 Total vectors in storage: {}", all_vectors.len());
-            
+            println!(" Total vectors in storage: {}", all_vectors.len());
+
             for (i, v) in all_vectors.iter().enumerate() {
                 println!("   Vector {}: {}", i, v.id);
             }
@@ -66,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check storage info
     let info = storage.get_storage_info()?;
-    println!("📊 Storage info: {:?}", info);
+    println!(" Storage info: {:?}", info);
 
     Ok(())
-} 
+}

--- a/vector_db/examples/local_storage_demo.rs
+++ b/vector_db/examples/local_storage_demo.rs
@@ -1,26 +1,26 @@
-use vector_db::{
-    vector::Vector,
-    local_storage::LocalStorage,
-    utils::generate_random_vectors,
-    index::{BruteForceIndex, Index},
-};
 use ndarray::Array1;
 use serde_json::json;
+use vector_db::{
+    index::{BruteForceIndex, Index},
+    local_storage::LocalStorage,
+    utils::generate_random_vectors,
+    vector::Vector,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🚀 Local Storage Vector Database Demo");
+    println!(" Local Storage Vector Database Demo");
     println!("=====================================");
 
     // Create local storage in current directory
     let mut storage = LocalStorage::new(".")?;
-    
-    println!("📁 Storage location: {:?}", storage.get_storage_path());
-    println!("✅ Local storage initialized");
+
+    println!(" Storage location: {:?}", storage.get_storage_path());
+    println!(" Local storage initialized");
 
     // Generate some test vectors
-    println!("\n📊 Generating 50 random 64-dimensional vectors...");
+    println!("\n Generating 50 random 64-dimensional vectors...");
     let vectors_data = generate_random_vectors(64, 50);
-    
+
     for (i, data) in vectors_data.into_iter().enumerate() {
         let metadata = json!({
             "index": i,
@@ -34,17 +34,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "priority": i % 5 + 1
             }
         });
-        
+
         let vector = Vector::with_metadata(data, metadata);
         storage.add_vector(&vector)?;
-        
+
         if (i + 1) % 10 == 0 {
             println!("  Added {} vectors", i + 1);
         }
     }
 
     // Get storage information
-    println!("\n📈 Storage Information:");
+    println!("\n Storage Information:");
     let info = storage.get_storage_info()?;
     for (key, value) in info.as_object().unwrap() {
         println!("  {}: {}", key, value);
@@ -55,56 +55,64 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Total vectors: {}", count);
 
     // Test vector retrieval
-    println!("\n🔍 Testing vector retrieval...");
+    println!("\n Testing vector retrieval...");
     let all_vectors = storage.get_all_vectors()?;
-    println!("  Retrieved {} vectors from local storage", all_vectors.len());
+    println!(
+        "  Retrieved {} vectors from local storage",
+        all_vectors.len()
+    );
 
     // Test individual vector retrieval
     if let Some(first_vector) = all_vectors.first() {
         let retrieved = storage.get_vector(&first_vector.id)?;
         match retrieved {
             Some(vector) => {
-                println!("  ✅ Successfully retrieved vector {}", vector.id);
+                println!("   Successfully retrieved vector {}", vector.id);
                 if let Some(metadata) = &vector.metadata {
-                    println!("  📝 Metadata: {}", metadata);
+                    println!("   Metadata: {}", metadata);
                 }
             }
-            None => println!("  ❌ Failed to retrieve vector"),
+            None => println!("   Failed to retrieve vector"),
         }
     }
 
     // Test similarity search
-    println!("\n🔎 Testing similarity search...");
+    println!("\n Testing similarity search...");
     let mut index = BruteForceIndex::new();
-    
+
     // Build index from storage vectors
-    let indexed_data: Vec<_> = all_vectors
-        .iter()
-        .map(|v| (&v.id, &v.data))
-        .collect();
+    let indexed_data: Vec<_> = all_vectors.iter().map(|v| (&v.id, &v.data)).collect();
     index.build(&indexed_data)?;
 
     // Perform search
     let query_data = generate_random_vectors(64, 1)[0].clone();
     let query_vector = Vector::new(query_data);
-    
+
     let results = index.query_with_similarity(&query_vector.data, 5, true);
     println!("  Top 5 similar vectors:");
     for (i, (vector_id, score)) in results.iter().enumerate() {
-        println!("    {}. Vector {} - Similarity: {:.4}", i + 1, vector_id, score);
+        println!(
+            "    {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector_id,
+            score
+        );
     }
 
     // Test vector deletion
-    println!("\n🗑️ Testing vector deletion...");
+    println!("\n Testing vector deletion...");
     if let Some(vector_to_delete) = all_vectors.first() {
         let initial_count = storage.get_vector_count()?;
         storage.delete_vector(&vector_to_delete.id)?;
         let final_count = storage.get_vector_count()?;
-        println!("  Deleted vector {}: {} -> {} vectors", vector_to_delete.id, initial_count, final_count);
+        println!(
+            "  Deleted vector {}: {} -> {} vectors",
+            vector_to_delete.id, initial_count, final_count
+        );
     }
 
     // Test metadata filtering
-    println!("\n🏷️ Testing metadata filtering...");
+    println!("\n Testing metadata filtering...");
     let vectors_with_metadata = storage.get_all_vectors()?;
     let category_a_vectors: Vec<_> = vectors_with_metadata
         .iter()
@@ -122,49 +130,49 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Found {} vectors in category A", category_a_vectors.len());
 
     // Show storage structure
-    println!("\n📂 Storage Structure:");
+    println!("\n Storage Structure:");
     let storage_path = storage.get_storage_path();
     println!("  Storage directory: {:?}", storage_path);
-    
+
     if storage_path.exists() {
         for entry in std::fs::read_dir(storage_path)? {
             let entry = entry?;
-            let file_type = if entry.file_type()?.is_dir() { "📁" } else { "📄" };
+            let file_type = if entry.file_type()?.is_dir() { "" } else { "" };
             println!("    {} {:?}", file_type, entry.file_name());
         }
     }
 
     // Test persistence across restarts
-    println!("\n🔄 Testing persistence...");
+    println!("\n Testing persistence...");
     let test_vector = Vector::with_metadata(
         Array1::from_vec(vec![1.0, 2.0, 3.0, 4.0]),
-        json!({"test": "persistence", "value": 42})
+        json!({"test": "persistence", "value": 42}),
     );
     storage.add_vector(&test_vector)?;
-    
+
     // Simulate restart by creating new storage instance
     let mut new_storage = LocalStorage::new(".")?;
     let retrieved = new_storage.get_vector(&test_vector.id)?;
-    
+
     match retrieved {
         Some(vector) => {
-            println!("  ✅ Persistence test passed - vector retrieved after restart");
+            println!("   Persistence test passed - vector retrieved after restart");
             if let Some(metadata) = &vector.metadata {
-                println!("  📝 Retrieved metadata: {}", metadata);
+                println!("   Retrieved metadata: {}", metadata);
             }
         }
-        None => println!("  ❌ Persistence test failed"),
+        None => println!("   Persistence test failed"),
     }
 
     // Final storage info
-    println!("\n📊 Final Storage Information:");
+    println!("\n Final Storage Information:");
     let final_info = storage.get_storage_info()?;
     for (key, value) in final_info.as_object().unwrap() {
         println!("  {}: {}", key, value);
     }
 
-    println!("\n✅ Local storage demo completed successfully!");
-    println!("💡 Check the .vector_storage directory to see the .kwi files!");
-    
+    println!("\n Local storage demo completed successfully!");
+    println!(" Check the .vector_storage directory to see the .kwi files!");
+
     Ok(())
-} 
+}

--- a/vector_db/examples/simple_local_test.rs
+++ b/vector_db/examples/simple_local_test.rs
@@ -1,62 +1,59 @@
-use vector_db::{
-    vector::Vector,
-    local_storage::LocalStorage,
-};
 use ndarray::Array1;
 use serde_json::json;
 use tempfile::TempDir;
+use vector_db::{local_storage::LocalStorage, vector::Vector};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🧪 Simple Local Storage Test");
+    println!(" Simple Local Storage Test");
     println!("============================");
 
     // Create a completely fresh temporary directory
     let temp_dir = TempDir::new()?;
-    println!("📁 Fresh temp directory: {:?}", temp_dir.path());
+    println!(" Fresh temp directory: {:?}", temp_dir.path());
 
     // Create storage
     let mut storage = LocalStorage::new(temp_dir.path())?;
-    println!("✅ Storage created");
+    println!(" Storage created");
 
     // Create a simple vector
     let data = Array1::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
     let metadata = json!({"test": "metadata", "value": 42});
     let vector = Vector::with_metadata(data, metadata);
-    
-    println!("📊 Vector created: {}", vector.id);
+
+    println!(" Vector created: {}", vector.id);
     println!("   Data: {:?}", vector.data);
     println!("   Metadata: {:?}", vector.metadata);
 
     // Add vector
     storage.add_vector(&vector)?;
-    println!("✅ Vector added to storage");
+    println!(" Vector added to storage");
 
     // Check count
     let count = storage.get_vector_count()?;
-    println!("📈 Vector count: {}", count);
+    println!(" Vector count: {}", count);
 
     // Try to retrieve vector
     let retrieved = storage.get_vector(&vector.id)?;
     match retrieved {
         Some(retrieved_vector) => {
-            println!("✅ Vector retrieved successfully!");
+            println!(" Vector retrieved successfully!");
             println!("   ID: {}", retrieved_vector.id);
             println!("   Data: {:?}", retrieved_vector.data);
             println!("   Metadata: {:?}", retrieved_vector.metadata);
         }
         None => {
-            println!("❌ Failed to retrieve vector");
+            println!(" Failed to retrieve vector");
         }
     }
 
     // Try to get all vectors
     let all_vectors = storage.get_all_vectors()?;
-    println!("📋 Total vectors in storage: {}", all_vectors.len());
+    println!(" Total vectors in storage: {}", all_vectors.len());
 
     // Check storage info
     let info = storage.get_storage_info()?;
-    println!("📊 Storage info: {:?}", info);
+    println!(" Storage info: {:?}", info);
 
-    println!("✅ Test completed!");
+    println!(" Test completed!");
     Ok(())
-} 
+}

--- a/vector_db/examples/sqlite_binary_demo.rs
+++ b/vector_db/examples/sqlite_binary_demo.rs
@@ -1,32 +1,35 @@
-use vector_db::{
-    vector::Vector,
-    collection_manager::CollectionManager,
-    utils::generate_random_vectors,
-    index::{BruteForceIndex, Index},
-    query::QueryEngine,
-};
 use ndarray::Array1;
 use std::collections::HashMap;
+use vector_db::{
+    collection_manager::CollectionManager,
+    index::{BruteForceIndex, Index},
+    query::QueryEngine,
+    utils::generate_random_vectors,
+    vector::Vector,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🚀 SQLite + Binary Index Vector Database Demo");
+    println!(" SQLite + Binary Index Vector Database Demo");
     println!("=============================================\n");
 
     // Create collection manager
     let db_path = std::env::temp_dir().join("vector_db_demo");
     let mut manager = CollectionManager::new(&db_path)?;
-    println!("📁 Database location: {:?}", db_path);
+    println!(" Database location: {:?}", db_path);
 
     // Create a collection
     let collection_name = "demo_collection";
     let dimension = 128;
     manager.create_collection(collection_name, dimension)?;
-    println!("✅ Created collection '{}' with dimension {}", collection_name, dimension);
+    println!(
+        " Created collection '{}' with dimension {}",
+        collection_name, dimension
+    );
 
     // Generate and add vectors
-    println!("\n📊 Adding vectors to collection...");
+    println!("\n Adding vectors to collection...");
     let vectors_data = generate_random_vectors(dimension, 100);
-    
+
     for (i, data) in vectors_data.into_iter().enumerate() {
         let metadata = serde_json::json!({
             "index": i,
@@ -37,107 +40,120 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .as_secs()
                 .to_string()
         });
-        
+
         let vector = Vector::with_metadata(data, metadata);
         manager.add_vector(collection_name, &vector)?;
-        
+
         if (i + 1) % 20 == 0 {
             println!("  Added {} vectors", i + 1);
         }
     }
 
     // Get collection info
-    println!("\n📈 Collection Information:");
+    println!("\n Collection Information:");
     let info = manager.get_collection_info(collection_name)?;
     for (key, value) in &info {
         println!("  {}: {}", key, value);
     }
 
     // List all collections
-    println!("\n📋 Available Collections:");
+    println!("\n Available Collections:");
     let collections = manager.list_collections()?;
     for collection in &collections {
         println!("  - {}", collection);
     }
 
     // Test vector retrieval
-    println!("\n🔍 Testing vector retrieval...");
+    println!("\n Testing vector retrieval...");
     let all_vectors = manager.get_all_vectors(collection_name)?;
-    println!("  Retrieved {} vectors from binary index", all_vectors.len());
+    println!(
+        "  Retrieved {} vectors from binary index",
+        all_vectors.len()
+    );
 
     // Test individual vector retrieval
     if let Some(first_vector) = all_vectors.first() {
         let retrieved = manager.get_vector(collection_name, &first_vector.id)?;
         match retrieved {
             Some(vector) => {
-                println!("  ✅ Successfully retrieved vector {}", vector.id);
+                println!("   Successfully retrieved vector {}", vector.id);
                 if let Some(metadata) = &vector.metadata {
-                    println!("  📝 Metadata: {}", metadata);
+                    println!("   Metadata: {}", metadata);
                 }
             }
-            None => println!("  ❌ Failed to retrieve vector"),
+            None => println!("   Failed to retrieve vector"),
         }
     }
 
     // Test similarity search with the collection
-    println!("\n🔎 Testing similarity search...");
+    println!("\n Testing similarity search...");
     let mut index = BruteForceIndex::new();
-    
+
     // Build index from collection vectors
-    let indexed_data: Vec<_> = all_vectors
-        .iter()
-        .map(|v| (&v.id, &v.data))
-        .collect();
+    let indexed_data: Vec<_> = all_vectors.iter().map(|v| (&v.id, &v.data)).collect();
     index.build(&indexed_data)?;
 
     // Perform search directly with the index
     let query_data = generate_random_vectors(dimension, 1)[0].clone();
     let query_vector = Vector::new(query_data);
-    
+
     let results = index.query_with_similarity(&query_vector.data, 5, true);
     println!("  Top 5 similar vectors:");
     for (i, (vector_id, score)) in results.iter().enumerate() {
-        println!("    {}. Vector {} - Similarity: {:.4}", i + 1, vector_id, score);
+        println!(
+            "    {}. Vector {} - Similarity: {:.4}",
+            i + 1,
+            vector_id,
+            score
+        );
     }
 
     // Test system info
-    println!("\n⚙️ System Information:");
+    println!("\n System Information:");
     let system_keys = ["created_at", "updated_at", "dimension", "vector_count"];
     for key in &system_keys {
-        if let Some(value) = manager.get_collection(collection_name)?.unwrap().sqlite_storage.get_system_info(key)? {
+        if let Some(value) = manager
+            .get_collection(collection_name)?
+            .unwrap()
+            .sqlite_storage
+            .get_system_info(key)?
+        {
             println!("  {}: {}", key, value);
         }
     }
 
     // Test vector deletion
-    println!("\n🗑️ Testing vector deletion...");
+    println!("\n Testing vector deletion...");
     if let Some(vector_to_delete) = all_vectors.first() {
         let initial_count = manager.count_vectors(collection_name)?;
         manager.delete_vector(collection_name, &vector_to_delete.id)?;
         let final_count = manager.count_vectors(collection_name)?;
-        println!("  Deleted vector {}: {} -> {} vectors", vector_to_delete.id, initial_count, final_count);
+        println!(
+            "  Deleted vector {}: {} -> {} vectors",
+            vector_to_delete.id, initial_count, final_count
+        );
     }
 
     // Test optimization
-    println!("\n🔧 Testing collection optimization...");
+    println!("\n Testing collection optimization...");
     manager.optimize_collection(collection_name)?;
-    println!("  ✅ Collection optimized");
+    println!("   Collection optimized");
 
     // Final collection info
-    println!("\n📊 Final Collection Information:");
+    println!("\n Final Collection Information:");
     let final_info = manager.get_collection_info(collection_name)?;
     for (key, value) in &final_info {
         println!("  {}: {}", key, value);
     }
 
     // Cleanup
-    println!("\n🧹 Cleaning up...");
+    println!("\n Cleaning up...");
     manager.delete_collection(collection_name)?;
     if db_path.exists() {
         std::fs::remove_dir_all(&db_path)?;
     }
-    println!("  ✅ Cleanup completed");
+    println!("   Cleanup completed");
 
-    println!("\n✅ SQLite + Binary Index demo completed successfully!");
+    println!("\n SQLite + Binary Index demo completed successfully!");
     Ok(())
-} 
+}

--- a/vector_db/minimal_test.rs
+++ b/vector_db/minimal_test.rs
@@ -7,27 +7,27 @@ fn test_basic_functionality() {
     let mut map = HashMap::new();
     map.insert("test", "value");
     assert_eq!(map.get("test"), Some(&"value"));
-    
+
     // Test 2: Vector operations (simulated)
     let vector_data = vec![1.0, 2.0, 3.0];
     assert_eq!(vector_data.len(), 3);
     assert_eq!(vector_data[0], 1.0);
-    
+
     // Test 3: String operations
     let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
     assert_eq!(uuid_str.len(), 36);
-    
+
     // Test 4: JSON-like operations
     let json_data = r#"{"id": "test", "data": [1, 2, 3]}"#;
     assert!(json_data.contains("test"));
-    
+
     // Test 5: Math operations
     let v1 = vec![1.0, 0.0, 0.0];
     let v2 = vec![0.0, 1.0, 0.0];
     let dot_product: f64 = v1.iter().zip(v2.iter()).map(|(a, b)| a * b).sum();
     assert_eq!(dot_product, 0.0);
-    
-    println!("✅ All basic functionality tests passed!");
+
+    println!(" All basic functionality tests passed!");
 }
 
 fn main() {
@@ -35,26 +35,26 @@ fn main() {
     let mut map = std::collections::HashMap::new();
     map.insert("test", "value");
     assert_eq!(map.get("test"), Some(&"value"));
-    
+
     // Test 2: Vector operations (simulated)
     let vector_data = vec![1.0, 2.0, 3.0];
     assert_eq!(vector_data.len(), 3);
     assert_eq!(vector_data[0], 1.0);
-    
+
     // Test 3: String operations
     let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
     assert_eq!(uuid_str.len(), 36);
-    
+
     // Test 4: JSON-like operations
     let json_data = r#"{"id": "test", "data": [1, 2, 3]}"#;
     assert!(json_data.contains("test"));
-    
+
     // Test 5: Math operations
     let v1 = vec![1.0, 0.0, 0.0];
     let v2 = vec![0.0, 1.0, 0.0];
     let dot_product: f64 = v1.iter().zip(v2.iter()).map(|(a, b)| a * b).sum();
     assert_eq!(dot_product, 0.0);
-    
-    println!("✅ All basic functionality tests passed!");
-    println!("🎉 Minimal test completed successfully!");
-} 
+
+    println!(" All basic functionality tests passed!");
+    println!(" Minimal test completed successfully!");
+}

--- a/vector_db/simple_test.rs
+++ b/vector_db/simple_test.rs
@@ -2,38 +2,38 @@
 use std::collections::HashMap;
 
 fn main() {
-    println!("🧪 Simple Vector Database Test");
+    println!(" Simple Vector Database Test");
     println!("=============================");
-    
+
     // Test 1: Basic data structures
     println!("\n1. Testing basic data structures...");
     let mut map = HashMap::new();
     map.insert("test", "value");
-    println!("   ✅ HashMap works: {}", map.get("test").unwrap());
-    
+    println!("    HashMap works: {}", map.get("test").unwrap());
+
     // Test 2: Vector operations (simulated)
     println!("\n2. Testing vector operations...");
     let vector_data = vec![1.0, 2.0, 3.0];
-    println!("   ✅ Vector data created: {:?}", vector_data);
-    println!("   ✅ Vector dimension: {}", vector_data.len());
-    
+    println!("    Vector data created: {:?}", vector_data);
+    println!("    Vector dimension: {}", vector_data.len());
+
     // Test 3: UUID generation (simulated)
     println!("\n3. Testing UUID generation...");
     let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
-    println!("   ✅ UUID format valid: {}", uuid_str);
-    
+    println!("    UUID format valid: {}", uuid_str);
+
     // Test 4: JSON serialization (simulated)
     println!("\n4. Testing JSON serialization...");
     let json_data = r#"{"id": "test", "data": [1, 2, 3]}"#;
-    println!("   ✅ JSON format valid: {}", json_data);
-    
+    println!("    JSON format valid: {}", json_data);
+
     // Test 5: Distance calculation (simulated)
     println!("\n5. Testing distance calculation...");
     let v1 = vec![1.0, 0.0, 0.0];
     let v2 = vec![0.0, 1.0, 0.0];
     let dot_product = v1.iter().zip(v2.iter()).map(|(a, b)| a * b).sum::<f64>();
-    println!("   ✅ Dot product calculated: {:.4}", dot_product);
-    
-    println!("\n🎉 All basic functionality tests passed!");
+    println!("    Dot product calculated: {:.4}", dot_product);
+
+    println!("\n All basic functionality tests passed!");
     println!("The project structure is correct and ready for full compilation.");
-} 
+}

--- a/vector_db/test_fixes.rs
+++ b/vector_db/test_fixes.rs
@@ -1,56 +1,56 @@
+use ndarray::Array1;
 use vector_db::{
-    vector::Vector,
-    storage::InMemoryStorage,
     index::BruteForceIndex,
     query::QueryEngine,
-    utils::{generate_random_vectors, cosine_similarity},
+    storage::InMemoryStorage,
+    utils::{cosine_similarity, generate_random_vectors},
+    vector::Vector,
 };
-use ndarray::Array1;
 
 fn main() {
-    println!("🧪 Testing Vector Database Fixes");
+    println!(" Testing Vector Database Fixes");
     println!("================================");
-    
+
     // Test 1: Basic vector creation
     println!("\n1. Testing vector creation...");
     let data = Array1::from_vec(vec![1.0, 2.0, 3.0]);
     let vector = Vector::new(data);
-    println!("   ✅ Vector created with dimension: {}", vector.dimension());
-    
+    println!("    Vector created with dimension: {}", vector.dimension());
+
     // Test 2: Storage operations
     println!("\n2. Testing storage operations...");
     let mut storage = InMemoryStorage::new();
     storage.insert(vector.clone()).unwrap();
-    println!("   ✅ Vector stored successfully");
-    println!("   ✅ Storage count: {}", storage.count());
-    
+    println!("    Vector stored successfully");
+    println!("    Storage count: {}", storage.count());
+
     // Test 3: Index operations
     println!("\n3. Testing index operations...");
     let mut index = BruteForceIndex::new();
     let indexed_data = vec![(&vector.id, &vector.data)];
     index.build(&indexed_data).unwrap();
-    println!("   ✅ Index built successfully");
-    
+    println!("    Index built successfully");
+
     // Test 4: Query engine
     println!("\n4. Testing query engine...");
     let query_engine = QueryEngine::new(&storage, &index);
     let results = query_engine.search(&vector, 1).unwrap();
-    println!("   ✅ Query executed successfully");
-    println!("   ✅ Found {} results", results.len());
-    
+    println!("    Query executed successfully");
+    println!("    Found {} results", results.len());
+
     // Test 5: Distance metrics
     println!("\n5. Testing distance metrics...");
     let v1 = Array1::from_vec(vec![1.0, 0.0, 0.0]);
     let v2 = Array1::from_vec(vec![0.0, 1.0, 0.0]);
     let cosine = cosine_similarity(&v1, &v2);
-    println!("   ✅ Cosine similarity calculated: {:.4}", cosine);
-    
+    println!("    Cosine similarity calculated: {:.4}", cosine);
+
     // Test 6: Random vector generation
     println!("\n6. Testing random vector generation...");
     let vectors = generate_random_vectors(128, 5);
-    println!("   ✅ Generated {} random vectors", vectors.len());
-    println!("   ✅ Vector dimension: {}", vectors[0].len());
-    
-    println!("\n🎉 All tests passed! The fixes are working correctly.");
+    println!("    Generated {} random vectors", vectors.len());
+    println!("    Vector dimension: {}", vectors[0].len());
+
+    println!("\n All tests passed! The fixes are working correctly.");
     println!("The vector database is now fully functional.");
-} 
+}


### PR DESCRIPTION
## Summary
- fix BruteForce index to clone referenced vectors correctly and return `Result`
- add locality-sensitive hashing index using random hyperplanes
- add hierarchical navigable small world index for fast approximate search
- remove all emojis from repository and update basic example
- update query engine, examples, and tests for new index trait

## Testing
- `cargo test`
- `rg --pcre2 "[\x{1F000}-\x{1FAFF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}]" -n`

------
https://chatgpt.com/codex/tasks/task_e_68944ab64b54832d9b048ca87e9030ef