### PR TITLE
Handle duplicate insert and missing delete errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod utils;
 pub mod vector;
 
 use thiserror::Error;
+use uuid::Uuid;
 
 #[derive(Error, Debug)]
 pub enum VectorDBError {
@@ -17,6 +18,10 @@ pub enum VectorDBError {
     PersistenceError(String),
     #[error("Serialization Error: {0}")]
     SerializationError(String),
+    #[error("Vector with ID {0} already exists")]
+    DuplicateId(Uuid),
+    #[error("Vector with ID {0} not found")]
+    MissingId(Uuid),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
## Summary
- Raise `VectorDBError::DuplicateId` when inserting a vector with an existing ID
- Raise `VectorDBError::MissingId` when deleting a non-existent vector
- Test storage error paths for duplicate insert and missing delete

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a77783aa38832d97a699366243ca6f